### PR TITLE
Animate player unit movement step-by-step (100ms delay)

### DIFF
--- a/src/components/GameGrid.vue
+++ b/src/components/GameGrid.vue
@@ -43,7 +43,7 @@ import GameCell from '@/components/GameCell.vue'
 import Models from '@/game/models'
 import { WaveEngine } from '@/game/waveEngine'
 import { FieldEngine } from '@/game/fieldEngine'
-import { ACTIONS } from '@/game/const'
+import { ACTIONS, UNIT_MOVE_ANIMATION_DELAY_MS } from '@/game/const'
 
 import emitter from '@/game/eventBus';
 import ActionHint from "@/components/ActionHint.vue";
@@ -185,14 +185,22 @@ export default {
         this.moveUnit(this.selectedCoords, [x, y]);
       }
     },
-    moveUnit(fromCoords, toCoords) {
+    async moveUnit(fromCoords, toCoords) {
       let [x, y] = fromCoords;
       // Save movePoints value for the further remove highlights
       const movePoints = this.field[x][y].unit.movePoints;
-      // Call game moveUnit function to change field
-      emitter.emit('moveUnit', {fromCoords: fromCoords, toCoords: toCoords});
+      const path = this.waveEngine.getPath(fromCoords, toCoords, movePoints);
+      for (let idx = 1; idx < path.length; idx++) {
+        emitter.emit('moveUnit', {fromCoords: path[idx - 1], toCoords: path[idx]});
+        if (idx < path.length - 1) {
+          await this.delay(UNIT_MOVE_ANIMATION_DELAY_MS);
+        }
+      }
       this.selectedCoords = null;
       this.removeHighlightsForArea(x, y, movePoints);
+    },
+    delay(ms) {
+      return new Promise(resolve => setTimeout(resolve, ms));
     },
     setAction(action) {
       this.selectedAction = action;

--- a/src/game/const.js
+++ b/src/game/const.js
@@ -1,4 +1,5 @@
 export const TRANSITION_DELAY = 1;
+export const UNIT_MOVE_ANIMATION_DELAY_MS = 100;
 // export const CELL_SIZE = 30;
 export const GAME_STATUS_FIELDS = [
   'winPhase',

--- a/src/game/waveEngine.js
+++ b/src/game/waveEngine.js
@@ -92,6 +92,44 @@ class WaveEngine {
     return false;
   }
 
+  getPath(fromCoords, toCoords, movePoints) {
+    const [x0, y0] = fromCoords;
+    const [x1, y1] = toCoords;
+    const waveField = this.getWaveField();
+    const parentByCoords = new Map();
+    const wave = [[x0, y0]];
+    waveField[x0][y0] = 0;
+
+    while (wave.length > 0) {
+      const [x, y] = wave.shift();
+      const s = waveField[x][y] + 1;
+      if (s > movePoints) break;
+
+      for (const [curX, curY] of this.getNeighbours(waveField, x, y)) {
+        if (waveField[curX][curY] !== null && waveField[curX][curY] <= s) continue;
+        waveField[curX][curY] = s;
+        parentByCoords.set(`${curX},${curY}`, [x, y]);
+        if (curX === x1 && curY === y1) {
+          return this.buildPath(parentByCoords, fromCoords, toCoords);
+        }
+        wave.push([curX, curY]);
+      }
+    }
+    return [];
+  }
+
+  buildPath(parentByCoords, fromCoords, toCoords) {
+    const path = [toCoords];
+    const [x0, y0] = fromCoords;
+    let current = toCoords;
+    while (current[0] !== x0 || current[1] !== y0) {
+      current = parentByCoords.get(`${current[0]},${current[1]}`);
+      if (!current) return [];
+      path.push(current);
+    }
+    return path.reverse();
+  }
+
   getNeighbours(field, x, y) {
     // console.log('getNeighbours start');
     const neighbours = [];


### PR DESCRIPTION
### Motivation
- Provide a simple per-cell animation for player unit moves so the unit visibly traverses the chosen path instead of teleporting.
- Make the animation timing configurable via a single constant for easy tuning later.
- Prepare code paths for smoother animation improvements in future (e.g. continuous sprite movement).

### Description
- Added `UNIT_MOVE_ANIMATION_DELAY_MS = 100` in `src/game/const.js` to centralize the per-step delay.
- Implemented path reconstruction in `src/game/waveEngine.js` with `getPath(fromCoords, toCoords, movePoints)` and `buildPath(...)` so the exact sequence of cells is available for step-by-step movement.
- Updated `src/components/GameGrid.vue` to perform player-initiated moves asynchronously; it now obtains the path via `waveEngine.getPath(...)`, emits `moveUnit` for each adjacent step, and waits `UNIT_MOVE_ANIMATION_DELAY_MS` between intermediate steps using an internal `delay` helper.
- Left bot movement logic unchanged (bots still perform moves without animation). 

### Testing
- Ran the test suite with `npm run test -- --run`, and all tests passed (`tests/DinoGame/dinogame.visibility.spec.js`: 7 tests passed).
- Ran `npm run lint`, which failed in the environment due to a missing `@babel/eslint-parser` dependency rather than code errors (environment issue).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5e1cbbd5083239fcab4606526b33e)