### PR TITLE
Fix Vite config path import for older Node runtimes

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -1,6 +1,6 @@
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
-import path from 'node:path'
+import path from 'path'
 
 export default defineConfig({
   plugins: [vue()],


### PR DESCRIPTION
### Motivation
- Fix a production build failure where Vite could not load `vite.config.js` because the `node:path` builtin specifier is not available in some older Node.js/runtime environments (manifested as `Error: Cannot find module 'node:path'`).

### Description
- Replace the `node:path` import with the traditional `path` import in `vite.config.js` to restore compatibility with environments that do not support `node:`-prefixed core module specifiers.

### Testing
- Ran `npm run build` which completed successfully producing the `dist` output; an attempt to run `yarn build` failed due to a Yarn/Corepack lockfile mismatch unrelated to the code changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f64b14b3b48323a50e9d53d187b30f)